### PR TITLE
Tweaked Telegram configuration docs and added an explicit error on message failure

### DIFF
--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -13,7 +13,7 @@ telegram:
   owner_id: 704338780
   sudo_users_id:
     - 704338780
-  target_chat_id: -100423424              # This is the chat where messages will be forwarded
+  target_chat_id: -100423424              # This is the chat where messages will be forwarded (note the "100" prefix of a supergroup)
   skip_video_stickers: false              # Setting this as true will stop trying to convert telegram video stickers to webp and sending them
   skip_setting_commands: false            # This will not show you list of commands when you start typing / in telegram
 

--- a/whatsapp/handlers.go
+++ b/whatsapp/handlers.go
@@ -1071,10 +1071,13 @@ func MessageFromOthersEventHandler(text string, v *events.Message) {
 				)
 			}
 		}
-		sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+		sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 			ReplyToMessageId: replyToMsgId,
 			MessageThreadId:  threadId,
 		})
+		if err != nil {
+			panic(fmt.Errorf("failed to send telegram message: %s", err))
+		}
 		if sentMsg.MessageId != 0 {
 			database.MsgIdAddNewPair(v.Info.ID, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 				cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)


### PR DESCRIPTION
Added printing an explicit error in case of Telegram misconfiguration
Amended sample_config.yaml to highlight a possible point of failure

Great project overall, just had to spend a significant amount of time figuring out why topics and messages were not mirroring correctly due to the error being silent