### PR TITLE
Improved Dockerfile to use multistage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,14 @@ FROM golang:1.19.8-alpine AS build
 
 RUN apk --no-cache add gcc g++ make git libwebp-dev libwebp-tools ffmpeg imagemagick
 WORKDIR /go/src/watgbridge
-COPY . /go/src/watgbridge
+COPY go.mod go.sum ./
+RUN go mod download
 
+COPY . ./
 RUN go build
 
+FROM alpine
+RUN apk --no-cache add tzdata libwebp-tools ffmpeg imagemagick
+WORKDIR /go/src/watgbridge
+COPY --from=build /go/src/watgbridge/watgbridge .
 CMD ["./watgbridge"]


### PR DESCRIPTION
Brings down image size from 1.07GB to 264MB

For your consideration, things that can be improved:
1. Allow configuring watgbridge to remove /updateandrestart in Docker (either in config.yaml or at build time)
2. Tinker with Dockerfile to avoid rebuilding everything on file changes that wouldn't result in a different build to speed up build times

Willing to send more pull requests if this one is approved!