### PR TITLE
fix(db): consider stanza id to find msg_id, best efforts

### DIFF
--- a/database/helpers.go
+++ b/database/helpers.go
@@ -45,9 +45,15 @@ func MsgIdGetTgFromWa(waMsgId, waChatId string) (int64, int64, int64, error) {
 
 	db := state.State.Database
 
+	var candidates []MsgIdPair
 	var bridgePair MsgIdPair
-	res := db.Where("id = ? AND wa_chat_id = ?", waMsgId, waChatId).Find(&bridgePair)
+	res := db.Where("id = ?", waMsgId).Find(&candidates)
 
+	if len(candidates) == 1 {
+		bridgePair = candidates[0]
+	} else if len(candidates) > 1 {
+		res = db.Where("id = ?  AND wa_chat_id = ?", waMsgId, waChatId).Find(&bridgePair)
+	}
 	return bridgePair.TgChatId, bridgePair.TgThreadId, bridgePair.TgMsgId, res.Error
 }
 


### PR DESCRIPTION
### Problem
Reply messages does not quote the original message it was replied to.


### Description
v.Info.Chat.String has two different values, PHONE & LID. When a new message arrives, v.Info.Chat is queried in msg_id_pairs table along with stanza id. However, query returns rows only when the current message has Info.Chat value same as the one recorded in msg_id_pairs table. 

Because Info.Chat can take two values, and only one of the two possibilty is stored in msg_id_pairs, the resolution breaks. 