### PR TITLE
fix: apply ephemeral timer to @all and .id commands

### DIFF
--- a/database/helpers_test.go
+++ b/database/helpers_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"testing"
+	"watgbridge/state"
 )
 
 func TestEphemeralSettingsStorageAndRetrieval(t *testing.T) {
@@ -11,12 +12,16 @@ func TestEphemeralSettingsStorageAndRetrieval(t *testing.T) {
 	// Note: This test requires database initialization which is done in main.
 	// For now, this is a placeholder to document expected behavior.
 
+	if state.State.Database == nil {
+		t.Skip("Database not initialized in test context")
+	}
+
 	testChatId := "1234567890@g.us"
 
 	// Store ephemeral settings
 	err := UpdateEphemeralSettings(testChatId, true, 86400)
 	if err != nil {
-		t.Skipf("Database not initialized in test context: %v", err)
+		t.Fatalf("Failed to update ephemeral settings: %v", err)
 	}
 
 	// Retrieve ephemeral settings

--- a/database/helpers_test.go
+++ b/database/helpers_test.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"testing"
+)
+
+func TestEphemeralSettingsStorageAndRetrieval(t *testing.T) {
+	// This test verifies that ephemeral settings can be stored and retrieved
+	// for a WhatsApp chat, which is the foundation for issue #46.
+
+	// Note: This test requires database initialization which is done in main.
+	// For now, this is a placeholder to document expected behavior.
+
+	testChatId := "1234567890@g.us"
+
+	// Store ephemeral settings
+	err := UpdateEphemeralSettings(testChatId, true, 86400)
+	if err != nil {
+		t.Skipf("Database not initialized in test context: %v", err)
+	}
+
+	// Retrieve ephemeral settings
+	isEphemeral, timer, found, err := GetEphemeralSettings(testChatId)
+	if err != nil {
+		t.Fatalf("Failed to get ephemeral settings: %v", err)
+	}
+
+	if !found {
+		t.Fatal("Ephemeral settings not found after being stored")
+	}
+
+	if !isEphemeral {
+		t.Error("Expected isEphemeral to be true")
+	}
+
+	if timer != 86400 {
+		t.Errorf("Expected timer to be 86400, got %d", timer)
+	}
+}

--- a/utils/whatsapp.go
+++ b/utils/whatsapp.go
@@ -203,7 +203,7 @@ func WaTagAll(group types.JID, msg *waE2E.Message, msgId, msgSender string, msgI
 
 	// Apply ephemeral settings if the chat has disappearing messages enabled
 	isEphemeral, ephemeralTimer, _, err := database.GetEphemeralSettings(group.String())
-	if err == nil && isEphemeral {
+	if err == nil && isEphemeral && ephemeralTimer > 0 {
 		contextInfo.Expiration = &ephemeralTimer
 	}
 

--- a/utils/whatsapp.go
+++ b/utils/whatsapp.go
@@ -194,15 +194,23 @@ func WaTagAll(group types.JID, msg *waE2E.Message, msgId, msgSender string, msgI
 		mentioned = append(mentioned, participant.JID.String())
 	}
 
+	contextInfo := &waE2E.ContextInfo{
+		StanzaID:      proto.String(msgId),
+		Participant:   proto.String(msgSender),
+		QuotedMessage: msg,
+		MentionedJID:  mentioned,
+	}
+
+	// Apply ephemeral settings if the chat has disappearing messages enabled
+	isEphemeral, ephemeralTimer, _, err := database.GetEphemeralSettings(group.String())
+	if err == nil && isEphemeral {
+		contextInfo.Expiration = &ephemeralTimer
+	}
+
 	_, err = waClient.SendMessage(context.Background(), group, &waE2E.Message{
 		ExtendedTextMessage: &waE2E.ExtendedTextMessage{
-			Text: proto.String(replyText),
-			ContextInfo: &waE2E.ContextInfo{
-				StanzaID:      proto.String(msgId),
-				Participant:   proto.String(msgSender),
-				QuotedMessage: msg,
-				MentionedJID:  mentioned,
-			},
+			Text:        proto.String(replyText),
+			ContextInfo: contextInfo,
 		},
 	})
 	if err != nil {

--- a/whatsapp/handlers.go
+++ b/whatsapp/handlers.go
@@ -130,7 +130,7 @@ func MessageFromMeEventHandler(text string, v *events.Message, isEdited bool) {
 
 		// Apply ephemeral settings if the chat has disappearing messages enabled
 		isEphemeral, ephemeralTimer, _, err := database.GetEphemeralSettings(v.Info.Chat.String())
-		if err == nil && isEphemeral {
+		if err == nil && isEphemeral && ephemeralTimer > 0 {
 			contextInfo.Expiration = &ephemeralTimer
 		}
 

--- a/whatsapp/handlers.go
+++ b/whatsapp/handlers.go
@@ -122,14 +122,22 @@ func MessageFromMeEventHandler(text string, v *events.Message, isEdited bool) {
 	if text == ".id" {
 		waClient := state.State.WhatsAppClient
 
-		_, err := waClient.SendMessage(context.Background(), v.Info.Chat, &waE2E.Message{
+		contextInfo := &waE2E.ContextInfo{
+			StanzaID:      proto.String(msgId),
+			Participant:   proto.String(v.Info.MessageSource.Sender.String()),
+			QuotedMessage: v.Message,
+		}
+
+		// Apply ephemeral settings if the chat has disappearing messages enabled
+		isEphemeral, ephemeralTimer, _, err := database.GetEphemeralSettings(v.Info.Chat.String())
+		if err == nil && isEphemeral {
+			contextInfo.Expiration = &ephemeralTimer
+		}
+
+		_, err = waClient.SendMessage(context.Background(), v.Info.Chat, &waE2E.Message{
 			ExtendedTextMessage: &waE2E.ExtendedTextMessage{
-				Text: proto.String(fmt.Sprintf("The ID of the current chat is:\n\n```%s```", v.Info.Chat.String())),
-				ContextInfo: &waE2E.ContextInfo{
-					StanzaID:      proto.String(msgId),
-					Participant:   proto.String(v.Info.MessageSource.Sender.String()),
-					QuotedMessage: v.Message,
-				},
+				Text:        proto.String(fmt.Sprintf("The ID of the current chat is:\n\n```%s```", v.Info.Chat.String())),
+				ContextInfo: contextInfo,
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
The ephemeral settings were already tracked in the database and applied in most message flows, but the @all/@everyone handler and .id command weren't checking them. Messages sent through these paths ignored disappearing message timers.

Both paths now call database.GetEphemeralSettings() and set ContextInfo.Expiration when the chat has disappearing messages enabled.

Fixes #46