### PR TITLE
fix: handle failed Telegram sends

### DIFF
--- a/whatsapp/handlers.go
+++ b/whatsapp/handlers.go
@@ -171,6 +171,18 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 		msgId = v.Info.ID
 	}
 
+	telegramSendOK := func(sentMsg *gotgbot.Message, err error) bool {
+		if err != nil {
+			logger.Error("failed to send message to Telegram",
+				zap.String("event_id", v.Info.ID),
+				zap.String("chat_jid", v.Info.Chat.String()),
+				zap.Error(err),
+			)
+			return false
+		}
+		return sentMsg != nil && sentMsg.MessageId != 0
+	}
+
 	if !isEdited {
 		// Return if duplicate event is emitted
 		tgChatId, _, _, _ := database.MsgIdGetTgFromWa(msgId, v.Info.Chat.String())
@@ -458,22 +470,22 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 		if cfg.WhatsApp.SkipImages {
 			bridgedText += "\n<i>Skipping image because 'skip_images' set in config file</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
 			return
 		} else if !cfg.Telegram.SelfHostedAPI && imageMsg.GetFileLength() > utils.UploadSizeLimit {
 			bridgedText += "\n<i>Couldn't send the photo as it exceeds Telegram size restrictions.</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -482,11 +494,11 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 			imageBytes, err := waClient.Download(context.Background(), imageMsg)
 			if err != nil {
 				bridgedText += "\n<i>Couldn't download the photo due to some errors</i>"
-				sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+				sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 					ReplyParameters: replyParameters,
 					MessageThreadId: threadId,
 				})
-				if sentMsg.MessageId != 0 {
+				if telegramSendOK(sentMsg, err) {
 					database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 						cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 				}
@@ -501,13 +513,13 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 				}
 			}
 
-			sentMsg, _ := tgBot.SendPhoto(cfg.Telegram.TargetChatID, &gotgbot.FileReader{Data: bytes.NewReader(imageBytes)}, &gotgbot.SendPhotoOpts{
+			sentMsg, err := tgBot.SendPhoto(cfg.Telegram.TargetChatID, &gotgbot.FileReader{Data: bytes.NewReader(imageBytes)}, &gotgbot.SendPhotoOpts{
 				Caption:         bridgedText,
 				ReplyParameters: replyParameters,
 				HasSpoiler:      imageMsg.GetViewOnce(),
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -523,22 +535,22 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 		if cfg.WhatsApp.SkipGIFs {
 			bridgedText += "\n<i>Skipping GIF because 'skip_gifs' set in config file</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
 			return
 		} else if !cfg.Telegram.SelfHostedAPI && gifMsg.GetFileLength() > utils.UploadSizeLimit {
 			bridgedText += "\n<i>Couldn't send the GIF as it exceeds Telegram size restrictions.</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -547,11 +559,11 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 			gifBytes, err := waClient.Download(context.Background(), gifMsg)
 			if err != nil {
 				bridgedText += "\n<i>Couldn't download the GIF due to some errors</i>"
-				sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+				sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 					ReplyParameters: replyParameters,
 					MessageThreadId: threadId,
 				})
-				if sentMsg.MessageId != 0 {
+				if telegramSendOK(sentMsg, err) {
 					database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 						cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 				}
@@ -571,12 +583,12 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 				Data: bytes.NewReader(gifBytes),
 			}
 
-			sentMsg, _ := tgBot.SendAnimation(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendAnimationOpts{
+			sentMsg, err := tgBot.SendAnimation(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendAnimationOpts{
 				Caption:         bridgedText,
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -600,22 +612,22 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 		if cfg.WhatsApp.SkipVideos {
 			bridgedText += "\n<i>Skipping video because 'skip_videos' set in config file</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
 			return
 		} else if !cfg.Telegram.SelfHostedAPI && videoMsg.GetFileLength() > utils.UploadSizeLimit {
 			bridgedText += "\n<i>Couldn't send the video as it exceeds Telegram size restrictions.</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -624,11 +636,11 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 			videoBytes, err := waClient.Download(context.Background(), videoMsg)
 			if err != nil {
 				bridgedText += "\n<i>Couldn't download the video due to some errors</i>"
-				sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+				sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 					ReplyParameters: replyParameters,
 					MessageThreadId: threadId,
 				})
-				if sentMsg.MessageId != 0 {
+				if telegramSendOK(sentMsg, err) {
 					database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 						cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 				}
@@ -650,20 +662,20 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 			var sentMsg *gotgbot.Message = nil
 			if isPtvMsg {
-				sentMsg, _ = tgBot.SendVideoNote(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendVideoNoteOpts{
+				sentMsg, err = tgBot.SendVideoNote(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendVideoNoteOpts{
 					ReplyMarkup:     replyMarkup,
 					ReplyParameters: replyParameters,
 					MessageThreadId: threadId,
 				})
 			} else {
-				sentMsg, _ = tgBot.SendVideo(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendVideoOpts{
+				sentMsg, err = tgBot.SendVideo(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendVideoOpts{
 					Caption:         bridgedText,
 					ReplyParameters: replyParameters,
 					HasSpoiler:      videoMsg.GetViewOnce(),
 					MessageThreadId: threadId,
 				})
 			}
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -679,22 +691,22 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 		if cfg.WhatsApp.SkipVoiceNotes {
 			bridgedText += "\n<i>Skipping voice note because 'skip_voice_notes' set in config file</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
 			return
 		} else if !cfg.Telegram.SelfHostedAPI && audioMsg.GetFileLength() > utils.UploadSizeLimit {
 			bridgedText += "\n<i>Couldn't send the audio as it exceeds Telegram size restrictions.</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -703,11 +715,11 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 			audioBytes, err := waClient.Download(context.Background(), audioMsg)
 			if err != nil {
 				bridgedText += "\n<i>Couldn't download the audio due to some errors</i>"
-				sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+				sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 					ReplyParameters: replyParameters,
 					MessageThreadId: threadId,
 				})
-				if sentMsg.MessageId != 0 {
+				if telegramSendOK(sentMsg, err) {
 					database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 						cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 				}
@@ -719,13 +731,13 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 				Data: bytes.NewReader(audioBytes),
 			}
 
-			sentMsg, _ := tgBot.SendAudio(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendAudioOpts{
+			sentMsg, err := tgBot.SendAudio(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendAudioOpts{
 				Caption:         bridgedText,
 				Duration:        int64(audioMsg.GetSeconds()),
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -741,22 +753,22 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 		if cfg.WhatsApp.SkipAudios {
 			bridgedText += "\n<i>Skipping audio because 'skip_audios' set in config file</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
 			return
 		} else if !cfg.Telegram.SelfHostedAPI && audioMsg.GetFileLength() > utils.UploadSizeLimit {
 			bridgedText += "\n<i>Couldn't send the audio as it exceeds Telegram size restrictions.</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -765,11 +777,11 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 			audioBytes, err := waClient.Download(context.Background(), audioMsg)
 			if err != nil {
 				bridgedText += "\n<i>Couldn't download the audio due to some errors</i>"
-				sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+				sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 					ReplyParameters: replyParameters,
 					MessageThreadId: threadId,
 				})
-				if sentMsg.MessageId != 0 {
+				if telegramSendOK(sentMsg, err) {
 					database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 						cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 				}
@@ -781,13 +793,13 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 				Data: bytes.NewReader(audioBytes),
 			}
 
-			sentMsg, _ := tgBot.SendAudio(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendAudioOpts{
+			sentMsg, err := tgBot.SendAudio(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendAudioOpts{
 				Caption:         bridgedText,
 				Duration:        int64(audioMsg.GetSeconds()),
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -803,22 +815,22 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 		if cfg.WhatsApp.SkipDocuments {
 			bridgedText += "\n<i>Skipping document because 'skip_documents' set in config file</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
 			return
 		} else if !cfg.Telegram.SelfHostedAPI && documentMsg.GetFileLength() > utils.UploadSizeLimit {
 			bridgedText += "\n<i>Couldn't send the document as it exceeds Telegram size restrictions.</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -827,11 +839,11 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 			documentBytes, err := waClient.Download(context.Background(), documentMsg)
 			if err != nil {
 				bridgedText += "\n<i>Couldn't download the document due to some errors</i>"
-				sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+				sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 					ReplyParameters: replyParameters,
 					MessageThreadId: threadId,
 				})
-				if sentMsg.MessageId != 0 {
+				if telegramSendOK(sentMsg, err) {
 					database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 						cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 				}
@@ -851,12 +863,12 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 				Data: bytes.NewReader(documentBytes),
 			}
 
-			sentMsg, _ := tgBot.SendDocument(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendDocumentOpts{
+			sentMsg, err := tgBot.SendDocument(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendDocumentOpts{
 				Caption:         bridgedText,
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -872,22 +884,22 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 		if cfg.WhatsApp.SkipStickers {
 			bridgedText += "\n<i>Skipping sticker because 'skip_stickers' set in config file</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
 			return
 		} else if !cfg.Telegram.SelfHostedAPI && stickerMsg.GetFileLength() > utils.UploadSizeLimit {
 			bridgedText += "\n<i>Couldn't send the sticker as it exceeds Telegram size restrictions.</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -896,11 +908,11 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 			stickerBytes, err := waClient.Download(context.Background(), stickerMsg)
 			if err != nil {
 				bridgedText += "\n<i>Couldn't download the sticker due to some errors</i>"
-				sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+				sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 					ReplyParameters: replyParameters,
 					MessageThreadId: threadId,
 				})
-				if sentMsg.MessageId != 0 {
+				if telegramSendOK(sentMsg, err) {
 					database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 						cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 				}
@@ -917,13 +929,13 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 					Data: bytes.NewReader(gifBytes),
 				}
 
-				sentMsg, _ := tgBot.SendAnimation(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendAnimationOpts{
+				sentMsg, err := tgBot.SendAnimation(cfg.Telegram.TargetChatID, &fileToSend, &gotgbot.SendAnimationOpts{
 					Caption:         bridgedText,
 					ReplyParameters: replyParameters,
 					MessageThreadId: threadId,
 					ReplyMarkup:     replyMarkup,
 				})
-				if sentMsg.MessageId != 0 {
+				if telegramSendOK(sentMsg, err) {
 					database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 						cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 				}
@@ -931,12 +943,12 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 			}
 		WEBP_TO_GIF_FAILED:
-			sentMsg, _ := tgBot.SendSticker(cfg.Telegram.TargetChatID, &gotgbot.FileReader{Data: bytes.NewReader(stickerBytes)}, &gotgbot.SendStickerOpts{
+			sentMsg, err := tgBot.SendSticker(cfg.Telegram.TargetChatID, &gotgbot.FileReader{Data: bytes.NewReader(stickerBytes)}, &gotgbot.SendStickerOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 				ReplyMarkup:     replyMarkup,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -947,11 +959,11 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 		if cfg.WhatsApp.SkipContacts {
 			bridgedText += "\n<i>Skipping contact because 'skip_contacts' set in config file</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -962,25 +974,25 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 		card, err := decoder.Decode()
 		if err != nil {
 			bridgedText += "\n<i>Couldn't send the vCard as failed to parse it</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
 			return
 		}
 
-		sentMsg, _ := tgBot.SendContact(cfg.Telegram.TargetChatID, card.PreferredValue(goVCard.FieldTelephone), contactMsg.GetDisplayName(),
+		sentMsg, err := tgBot.SendContact(cfg.Telegram.TargetChatID, card.PreferredValue(goVCard.FieldTelephone), contactMsg.GetDisplayName(),
 			&gotgbot.SendContactOpts{
 				Vcard:           contactMsg.GetVcard(),
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 				ReplyMarkup:     replyMarkup,
 			})
-		if sentMsg.MessageId != 0 {
+		if telegramSendOK(sentMsg, err) {
 			database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 				cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 		}
@@ -992,11 +1004,11 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 		if cfg.WhatsApp.SkipContacts {
 			bridgedText += "\n<i>Skipping contact array because 'skip_contacts' set in config file</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -1014,14 +1026,14 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 				continue
 			}
 
-			sentMsg, _ := tgBot.SendContact(cfg.Telegram.TargetChatID, card.PreferredValue(goVCard.FieldTelephone), contactMsg.GetDisplayName(),
+			sentMsg, err := tgBot.SendContact(cfg.Telegram.TargetChatID, card.PreferredValue(goVCard.FieldTelephone), contactMsg.GetDisplayName(),
 				&gotgbot.SendContactOpts{
 					Vcard:           contactMsg.GetVcard(),
 					ReplyParameters: replyParameters,
 					MessageThreadId: threadId,
 					ReplyMarkup:     replyMarkup,
 				})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
@@ -1034,23 +1046,23 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 		if cfg.WhatsApp.SkipLocations {
 			bridgedText += "\n<i>Skipping location because 'skip_locations' set in config file</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
 			return
 		}
-		sentMsg, _ := tgBot.SendLocation(cfg.Telegram.TargetChatID, locationMsg.GetDegreesLatitude(), locationMsg.GetDegreesLongitude(),
+		sentMsg, err := tgBot.SendLocation(cfg.Telegram.TargetChatID, locationMsg.GetDegreesLatitude(), locationMsg.GetDegreesLongitude(),
 			&gotgbot.SendLocationOpts{
 				HorizontalAccuracy: float64(locationMsg.GetAccuracyInMeters()),
 				ReplyParameters:    replyParameters,
 				MessageThreadId:    threadId,
 			})
-		if sentMsg.MessageId != 0 {
+		if telegramSendOK(sentMsg, err) {
 			database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 				cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 		}
@@ -1063,22 +1075,22 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 
 		if cfg.WhatsApp.SkipLocations {
 			bridgedText += "\n<i>Skipping live location because 'skip_locations' set in config file</i>"
-			sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+			sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 				ReplyParameters: replyParameters,
 				MessageThreadId: threadId,
 			})
-			if sentMsg.MessageId != 0 {
+			if telegramSendOK(sentMsg, err) {
 				database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 					cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 			}
 			return
 		}
 
-		sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+		sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 			ReplyParameters: replyParameters,
 			MessageThreadId: threadId,
 		})
-		if sentMsg.MessageId != 0 {
+		if telegramSendOK(sentMsg, err) {
 			database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 				cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 		}
@@ -1106,11 +1118,11 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 			bridgedText += fmt.Sprintf("%v. %s\n", optionNum+1, html.EscapeString(option.GetOptionName()))
 		}
 
-		sentMsg, _ := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
+		sentMsg, err := tgBot.SendMessage(cfg.Telegram.TargetChatID, bridgedText, &gotgbot.SendMessageOpts{
 			ReplyParameters: replyParameters,
 			MessageThreadId: threadId,
 		})
-		if sentMsg.MessageId != 0 {
+		if telegramSendOK(sentMsg, err) {
 			database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 				cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 		}
@@ -1164,7 +1176,7 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 					if err != nil {
 						panic(fmt.Errorf("failed to send telegram message: %s", err))
 					}
-					if sentMsg.MessageId != 0 {
+					if telegramSendOK(sentMsg, err) {
 						database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), waChatIdForLookup,
 							cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 					}
@@ -1202,7 +1214,7 @@ func MessageFromOthersEventHandler(text string, v *events.Message, isEdited bool
 		if err != nil {
 			panic(fmt.Errorf("failed to send telegram message: %s", err))
 		}
-		if sentMsg.MessageId != 0 {
+		if telegramSendOK(sentMsg, err) {
 			database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 				cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 		}
@@ -1315,7 +1327,7 @@ func UndecryptableMessageEventHandler(v *events.UndecryptableMessage) {
 	if err != nil {
 		panic(fmt.Errorf("failed to send telegram message: %s", err))
 	}
-	if sentMsg.MessageId != 0 {
+	if sentMsg != nil && sentMsg.MessageId != 0 {
 		database.MsgIdAddNewPair(msgId, v.Info.MessageSource.Sender.String(), v.Info.Chat.String(),
 			cfg.Telegram.TargetChatID, sentMsg.MessageId, sentMsg.MessageThreadId)
 	}


### PR DESCRIPTION
### Summary

Avoid panics when Telegram send calls fail and return a nil message.

### Context

I hit this in a long-running Docker deployment on `v1.13.4`:

```text
Event handler panicked while handling a *events.Message:
runtime error: invalid memory address or nil pointer dereference

watgbridge/whatsapp.MessageFromOthersEventHandler
/go/src/watgbridge/whatsapp/handlers.go:510
/go/src/watgbridge/whatsapp/handlers.go:666
```

Those paths call Telegram send methods, ignore the returned error, then dereference `sentMsg.MessageId`.

If the Telegram API call fails and `sentMsg` is nil, the handler panics.

### Change

- Check Telegram send errors before using the returned message.
- Guard `sentMsg != nil` before reading `MessageId`.
- Keep existing message-id mapping behavior unchanged when sending succeeds.

### Notes

I searched existing issues/PRs for `nil pointer`, `panic`, `SendPhoto`, `SendSticker`, and `MessageId`, but did not find an existing report for this failure mode.

### Test

```text
go test ./...
```

Passes locally.